### PR TITLE
fix PHP7.4 deprecated

### DIFF
--- a/src/RedisClient.php
+++ b/src/RedisClient.php
@@ -29,7 +29,7 @@ class RedisClient
             $port = $arr[1] ?? 6739;
 
             $redis = new \Redis();
-            if ($host{0} == '/'){//.sock模式
+            if ($host[0] == '/'){//.sock模式
                 $connect = $redis->connect($host);
             } else {
                 $connect = $redis->connect($host, $port);


### PR DESCRIPTION
PHP 7.4 deprecated the use of curly braces to access array/string indexes resulting in errors like this:

```
[xxxx-xx-xx xx:xx:xx][debug][notice]:[Array and string offset access syntax with curly braces is deprecated at file:/path/to/vendor/rayswoole/redis-pool/src/RedisClient.php line:32]
```

This change makes the code compatible with PHP7.4.

For more information on the deprecation see: https://wiki.php.net/rfc/deprecate_curly_braces_array_access